### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mmap.opam
+++ b/mmap.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.6"}
+  "dune" {>= "1.6"}
 ]
 synopsis: "File mapping functionality"
 description: """


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.