### PR TITLE
Allow building with OCaml 5.00

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name mmap)
  (modules mmap)
- (libraries unix bigarray))
+ (libraries unix))
 
 (rule
  (with-stdout-to selected (run %{ocaml} %{dep:which_mmap.ml} %{ocaml_version})))


### PR DESCRIPTION
Do we need to preserve `(libraries bigarray)` for older versions? How many versions back is mmap supposed to support?